### PR TITLE
fix: Define the additional WarningsNotAsErrors property values in the…

### DIFF
--- a/build/default.props
+++ b/build/default.props
@@ -7,7 +7,7 @@
   
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsNotAsErrors>612,618</WarningsNotAsErrors>
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);612,618</WarningsNotAsErrors>
   </PropertyGroup>
   
 </Project>


### PR DESCRIPTION
… way to append the them to the ones that might already be defined in other property files instead of overwriting the existing ones.